### PR TITLE
Dns preload

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,8 +55,7 @@ type AWSRegion struct {
 // CheckLatencyHTTP Test Latency via HTTP
 func (r *AWSRegion) CheckLatencyHTTP(wg *sync.WaitGroup) {
 	defer wg.Done()
-	url := fmt.Sprintf("http://%s.%s.amazonaws.com/ping?x=%s", r.Service,
-		r.Code, mkRandoString(13))
+	url := fmt.Sprintf("http://%s/ping?x=%s", r.GetTarget(), mkRandoString(13))
 	client := &http.Client{}
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -70,11 +69,16 @@ func (r *AWSRegion) CheckLatencyHTTP(wg *sync.WaitGroup) {
 	r.Error = err
 }
 
+func (r *AWSRegion) GetTarget() string {
+	return fmt.Sprintf("%s.%s.amazonaws.com", r.Service, r.Code)
+}
+
 // CheckLatencyTCP Test Latency via TCP
 func (r *AWSRegion) CheckLatencyTCP(wg *sync.WaitGroup) {
 	defer wg.Done()
-	tcpURI := fmt.Sprintf("%s.%s.amazonaws.com:80", r.Service, r.Code)
+	tcpURI := fmt.Sprintf("%s:80", r.GetTarget())
 	tcpAddr, err := net.ResolveTCPAddr("tcp4", tcpURI)
+
 	if err != nil {
 		r.Error = err
 		return


### PR DESCRIPTION
This PR aims to avoid DNS resolution to be done at the time an HTTP or an HTTPS request is being done. 


before: 
```
./awsping -http -repeats 3 -verbose 2
      Code            Region                             Try #1          Try #2          Try #3     Avg Latency
    0 eu-central-1    Europe (Frankfurt)               58.93 ms        50.04 ms        49.44 ms        52.14 ms
    1 eu-south-1      Europe (Milan)                   77.22 ms        54.62 ms        54.34 ms        62.06 ms
    2 eu-west-3       Europe (Paris)                   76.70 ms        59.90 ms        59.67 ms        65.42 ms
    3 eu-west-2       Europe (London)                  96.93 ms        69.79 ms        69.43 ms        78.72 ms
    4 eu-north-1      Europe (Stockholm)              101.33 ms        89.63 ms        89.99 ms        93.65 ms
```
_the first try takes significantly more time than the following ones_

after: 
```
./awsping -http -repeats 3 -verbose 2
      Code            Region                             Try #1          Try #2          Try #3     Avg Latency
    0 eu-central-1    Europe (Frankfurt)               42.42 ms        44.20 ms        45.51 ms        43.38 ms
    1 eu-south-1      Europe (Milan)                   50.62 ms        48.84 ms        45.06 ms        48.17 ms
    2 eu-west-3       Europe (Paris)                   55.75 ms        49.29 ms        54.05 ms        53.03 ms
    3 eu-west-2       Europe (London)                  64.55 ms        67.16 ms        65.88 ms        65.87 ms
    4 eu-west-1       Europe (Ireland)                 81.29 ms        85.92 ms        80.19 ms        82.47 ms
```

