### PR TITLE
Add -us flag to only ping US regions

### DIFF
--- a/cmd/awsping/main.go
+++ b/cmd/awsping/main.go
@@ -18,6 +18,7 @@ var (
 	verbose     = flag.Int("verbose", 0, "Verbosity level (0: name-latency); 1: code-name-latency; 2: code-name-tries-avg")
 	service     = flag.String("service", "dynamodb", "AWS Service: ec2, sdb, sns, sqs, ...")
 	listRegions = flag.Bool("list-regions", false, "Show list of regions")
+	usOnly      = flag.Bool("us", false, "Only US regions")
 )
 
 func main() {
@@ -29,6 +30,9 @@ func main() {
 	}
 
 	regions := awsping.GetRegions()
+	if *usOnly {
+		regions = awsping.GetRegionsUS()
+	}
 
 	if *listRegions {
 		lo := awsping.NewOutput(awsping.ShowOnlyRegions, 0)

--- a/utils.go
+++ b/utils.go
@@ -116,13 +116,28 @@ func (lo *LatencyOutput) Show(regions *AWSRegions) {
 	}
 }
 
-// GetRegions returns a list of regions
+// GetRegions returns a list of all regions
 func GetRegions() AWSRegions {
+	us := GetRegionsUS()
+	other := GetNonUSRegions()
+
+	return append(us, other...)
+}
+
+// GetRegionsUS returns a list of regions
+func GetRegionsUS() AWSRegions {
 	return AWSRegions{
 		NewRegion("US-East (N. Virginia)", "us-east-1"),
 		NewRegion("US-East (Ohio)", "us-east-2"),
 		NewRegion("US-West (N. California)", "us-west-1"),
 		NewRegion("US-West (Oregon)", "us-west-2"),
+	}
+}
+
+// GetRegions returns a list of regions
+func GetNonUSRegions() AWSRegions {
+
+	return AWSRegions{
 		NewRegion("Canada (Central)", "ca-central-1"),
 		NewRegion("Europe (Ireland)", "eu-west-1"),
 		NewRegion("Europe (Frankfurt)", "eu-central-1"),


### PR DESCRIPTION
Great utility! 
I am only interested in US regions. The other regions slow down the results. 
So, I learned enough Go to add a new flag -us that only pings US regions.
And, TIL how to fork and create a GH pull request for the first time, so I could contribute. 😄 