### PR TITLE
fix(latency): preserve per-attempt results

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -18,14 +18,23 @@ const (
 	CheckTypeHTTPS
 )
 
+// AttemptResult describes the outcome of a single latency check.
+type AttemptResult struct {
+	Latency time.Duration
+	Err     error
+}
+
 // --------------------------------------------
 
 // AWSRegion description of the AWS EC2 region
 type AWSRegion struct {
-	Name      string
-	Code      string
-	Service   string
+	Name     string
+	Code     string
+	Service  string
+	Attempts []AttemptResult
+	// Latencies is kept for backward compatibility. New code should use Attempts.
 	Latencies []time.Duration
+	// Error is kept for backward compatibility. New code should use LastError.
 	Error     error
 	CheckType CheckType
 
@@ -58,44 +67,125 @@ func (r *AWSRegion) CheckLatency(wg *sync.WaitGroup) {
 func (r *AWSRegion) checkLatencyHTTP(https bool) {
 	url := r.Target.GetURL()
 	l, err := r.Request.Do(useragent, url, RequestTypeHTTP)
-	if err != nil {
-		r.Error = err
-		return
-	}
-	r.Latencies = append(r.Latencies, l)
+	r.recordAttempt(l, err)
 }
 
 // checkLatencyTCP Test Latency via TCP
 func (r *AWSRegion) checkLatencyTCP() {
 	tcpAddr, err := r.Target.GetIP()
 	if err != nil {
-		r.Error = err
+		r.recordAttempt(0, err)
 		return
 	}
 
 	l, err := r.Request.Do(useragent, tcpAddr.String(), RequestTypeTCP)
+	r.recordAttempt(l, err)
+}
+
+func (r *AWSRegion) recordAttempt(latency time.Duration, err error) {
+	r.Attempts = append(r.Attempts, AttemptResult{
+		Latency: latency,
+		Err:     err,
+	})
+
 	if err != nil {
 		r.Error = err
 		return
 	}
-	r.Latencies = append(r.Latencies, l)
+
+	r.Latencies = append(r.Latencies, latency)
+}
+
+// SuccessfulAttempts returns the number of checks completed without an error.
+func (r *AWSRegion) SuccessfulAttempts() int {
+	if len(r.Attempts) == 0 {
+		return len(r.Latencies)
+	}
+
+	successful := 0
+	for _, attempt := range r.Attempts {
+		if attempt.Err == nil {
+			successful++
+		}
+	}
+	return successful
+}
+
+// FailedAttempts returns the number of checks completed with an error.
+func (r *AWSRegion) FailedAttempts() int {
+	if len(r.Attempts) == 0 {
+		if r.Error != nil {
+			return 1
+		}
+		return 0
+	}
+
+	failed := 0
+	for _, attempt := range r.Attempts {
+		if attempt.Err != nil {
+			failed++
+		}
+	}
+	return failed
+}
+
+// AverageLatency returns the average latency of successful attempts.
+func (r *AWSRegion) AverageLatency() (time.Duration, bool) {
+	if len(r.Attempts) == 0 {
+		if len(r.Latencies) == 0 {
+			return 0, false
+		}
+
+		var total time.Duration
+		for _, latency := range r.Latencies {
+			total += latency
+		}
+		return total / time.Duration(len(r.Latencies)), true
+	}
+
+	var total time.Duration
+	successful := 0
+	for _, attempt := range r.Attempts {
+		if attempt.Err != nil {
+			continue
+		}
+		total += attempt.Latency
+		successful++
+	}
+	if successful == 0 {
+		return 0, false
+	}
+	return total / time.Duration(successful), true
+}
+
+// LastError returns the error from the most recent failed attempt.
+func (r *AWSRegion) LastError() error {
+	for i := len(r.Attempts) - 1; i >= 0; i-- {
+		if r.Attempts[i].Err != nil {
+			return r.Attempts[i].Err
+		}
+	}
+	return r.Error
 }
 
 // GetLatency returns Latency in ms
 func (r *AWSRegion) GetLatency() float64 {
-	sum := float64(0)
-	for _, l := range r.Latencies {
-		sum += Duration2ms(l)
+	latency, ok := r.AverageLatency()
+	if !ok {
+		return 0
 	}
-	return sum / float64(len(r.Latencies))
+	return Duration2ms(latency)
 }
 
 // GetLatencyStr returns Latency in string
 func (r *AWSRegion) GetLatencyStr() string {
-	if r.Error != nil {
-		return r.Error.Error()
+	if latency, ok := r.AverageLatency(); ok {
+		return fmt.Sprintf("%.2f ms", Duration2ms(latency))
 	}
-	return fmt.Sprintf("%.2f ms", r.GetLatency())
+	if err := r.LastError(); err != nil {
+		return err.Error()
+	}
+	return "-"
 }
 
 // --------------------------------------------
@@ -110,7 +200,16 @@ func (rs AWSRegions) Len() int {
 
 // Less return a result of latency compare between two regions
 func (rs AWSRegions) Less(i, j int) bool {
-	return rs[i].GetLatency() < rs[j].GetLatency()
+	left, leftOK := rs[i].AverageLatency()
+	right, rightOK := rs[j].AverageLatency()
+
+	if leftOK != rightOK {
+		return leftOK
+	}
+	if !leftOK {
+		return false
+	}
+	return left < right
 }
 
 // Swap two regions by index

--- a/aws_test.go
+++ b/aws_test.go
@@ -96,6 +96,22 @@ func (d *testRequest) Do(_, _ string, _ RequestType) (time.Duration, error) {
 	return d.duration, nil
 }
 
+type testRequestResult struct {
+	duration time.Duration
+	err      error
+}
+
+type sequenceRequest struct {
+	results []testRequestResult
+	next    int
+}
+
+func (r *sequenceRequest) Do(_, _ string, _ RequestType) (time.Duration, error) {
+	result := r.results[r.next]
+	r.next++
+	return result.duration, result.err
+}
+
 func TestAWSRegionCheckLatencyTCP(t *testing.T) {
 	// just random local IP
 	tt := testTarget{IP: &net.TCPAddr{
@@ -145,6 +161,84 @@ func TestAWSRegionCheckLatencyTCP(t *testing.T) {
 	}
 }
 
+func TestAWSRegionAttemptsPreserveFailures(t *testing.T) {
+	errFirst := errors.New("first attempt failed")
+	region := NewRegion("Test", "test-1")
+	region.Target = &testTarget{IP: &net.TCPAddr{
+		IP:   net.IPv4(127, 0, 0, 1),
+		Port: 67890,
+	}}
+	region.Request = &sequenceRequest{results: []testRequestResult{
+		{err: errFirst},
+		{duration: 15 * time.Millisecond},
+		{duration: 25 * time.Millisecond},
+	}}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		region.CheckLatency(&wg)
+	}
+
+	if got, want := len(region.Attempts), 3; got != want {
+		t.Fatalf("attempt count: got %d, want %d", got, want)
+	}
+	if !errors.Is(region.Attempts[0].Err, errFirst) {
+		t.Errorf("first attempt error: got %v, want %v", region.Attempts[0].Err, errFirst)
+	}
+	if region.Attempts[1].Err != nil {
+		t.Errorf("second attempt error: got %v, want nil", region.Attempts[1].Err)
+	}
+	if got, want := region.Attempts[1].Latency, 15*time.Millisecond; got != want {
+		t.Errorf("second attempt latency: got %v, want %v", got, want)
+	}
+	if got, want := region.SuccessfulAttempts(), 2; got != want {
+		t.Errorf("successful attempts: got %d, want %d", got, want)
+	}
+	if got, want := region.FailedAttempts(), 1; got != want {
+		t.Errorf("failed attempts: got %d, want %d", got, want)
+	}
+	if got, want := region.GetLatencyStr(), "20.00 ms"; got != want {
+		t.Errorf("latency string: got %q, want %q", got, want)
+	}
+}
+
+func TestAWSRegionAllAttemptsFailed(t *testing.T) {
+	errFirst := errors.New("first attempt failed")
+	errLast := errors.New("last attempt failed")
+	region := AWSRegion{Attempts: []AttemptResult{
+		{Err: errFirst},
+		{Err: errLast},
+	}}
+
+	if latency, ok := region.AverageLatency(); ok || latency != 0 {
+		t.Errorf("average latency: got (%v, %t), want (0, false)", latency, ok)
+	}
+	if got := region.GetLatency(); got != 0 {
+		t.Errorf("latency: got %f, want 0", got)
+	}
+	if got, want := region.GetLatencyStr(), errLast.Error(); got != want {
+		t.Errorf("latency string: got %q, want %q", got, want)
+	}
+	if !errors.Is(region.LastError(), errLast) {
+		t.Errorf("last error: got %v, want %v", region.LastError(), errLast)
+	}
+}
+
+func TestAWSRegionWithoutAttempts(t *testing.T) {
+	region := AWSRegion{}
+
+	if latency, ok := region.AverageLatency(); ok || latency != 0 {
+		t.Errorf("average latency: got (%v, %t), want (0, false)", latency, ok)
+	}
+	if got := region.GetLatency(); got != 0 {
+		t.Errorf("latency: got %f, want 0", got)
+	}
+	if got, want := region.GetLatencyStr(), "-"; got != want {
+		t.Errorf("latency string: got %q, want %q", got, want)
+	}
+}
+
 // ---------------------------------------------
 
 func TestAWSRegionsLen(t *testing.T) {
@@ -166,6 +260,20 @@ func TestAWSRegionsLess(t *testing.T) {
 
 	if !regions.Less(0, 1) {
 		t.Errorf("failed: not less, regions=%q", regions)
+	}
+}
+
+func TestAWSRegionsLessPutsFailedRegionsLast(t *testing.T) {
+	regions := AWSRegions{
+		{Name: "Failed", Attempts: []AttemptResult{{Err: errors.New("failed")}}},
+		{Name: "Successful", Attempts: []AttemptResult{{Latency: 25 * time.Millisecond}}},
+	}
+
+	if regions.Less(0, 1) {
+		t.Error("failed region should not sort before a successful region")
+	}
+	if !regions.Less(1, 0) {
+		t.Error("successful region should sort before a failed region")
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -94,10 +94,22 @@ func (lo *LatencyOutput) show2(regions *AWSRegions) {
 	for i, r := range *regions {
 		outData := []interface{}{strconv.Itoa(i), r.Code, r.Name}
 		for n := 0; n < lo.Repeats; n++ {
-			outData = append(outData, fmt.Sprintf("%.2f ms",
-				Duration2ms(r.Latencies[n])))
+			switch {
+			case n < len(r.Attempts) && r.Attempts[n].Err == nil:
+				outData = append(outData, fmt.Sprintf("%.2f ms",
+					Duration2ms(r.Attempts[n].Latency)))
+			case len(r.Attempts) == 0 && n < len(r.Latencies):
+				outData = append(outData, fmt.Sprintf("%.2f ms",
+					Duration2ms(r.Latencies[n])))
+			default:
+				outData = append(outData, "-")
+			}
 		}
-		outData = append(outData, fmt.Sprintf("%.2f ms", r.GetLatency()))
+		if latency, ok := r.AverageLatency(); ok {
+			outData = append(outData, fmt.Sprintf("%.2f ms", Duration2ms(latency)))
+		} else {
+			outData = append(outData, "-")
+		}
 		fmt.Fprintf(lo.w, outFmt, outData...)
 	}
 }
@@ -175,5 +187,5 @@ func CalcLatency(regions AWSRegions, repeats int, useHTTP bool, useHTTPS bool, s
 		wg.Wait()
 	}
 
-	sort.Sort(regions)
+	sort.Stable(regions)
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,6 +2,7 @@ package awsping
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 	"time"
 )
@@ -114,6 +115,35 @@ func TestOutputShow2(t *testing.T) {
 	}
 }
 
+func TestOutputShow2PreservesFailedAttemptPositions(t *testing.T) {
+	var b bytes.Buffer
+
+	lo := NewOutput(2, 3)
+	lo.w = &b
+
+	regions := GetRegions()[:2]
+	regions[0].Attempts = []AttemptResult{
+		{Err: errors.New("timeout")},
+		{Latency: 17 * time.Millisecond},
+		{Err: errors.New("connection refused")},
+	}
+	regions[1].Attempts = []AttemptResult{
+		{Err: errors.New("timeout")},
+		{Err: errors.New("timeout")},
+		{Err: errors.New("timeout")},
+	}
+
+	lo.Show(&regions)
+
+	got := b.String()
+	want := "      Code            Region                             Try #1          Try #2          Try #3     Avg Latency\n" +
+		"    0 af-south-1      Africa (Cape Town)                      -        17.00 ms               -        17.00 ms\n" +
+		"    1 ap-east-1       Asia Pacific (Hong Kong)                -               -               -               -\n"
+	if got != want {
+		t.Errorf("Show2 failed:\ngot =%q\nwant=%q", got, want)
+	}
+}
+
 func TestCalcLatency(t *testing.T) {
 
 	regions := GetRegions()[:3]
@@ -148,5 +178,24 @@ func TestCalcLatency(t *testing.T) {
 		checkSort(0, 2)
 		checkSort(1, 0)
 		checkSort(2, 1)
+	}
+}
+
+func TestCalcLatencySortsFailedRegionsLast(t *testing.T) {
+	regions := GetRegions()[:3]
+	regions[0].Request = &testRequest{err: errors.New("first failed")}
+	regions[1].Request = &testRequest{duration: 7 * time.Millisecond}
+	regions[2].Request = &testRequest{err: errors.New("third failed")}
+
+	CalcLatency(regions, 1, false, false, "ec2")
+
+	if got, want := regions[0].Name, "Asia Pacific (Hong Kong)"; got != want {
+		t.Errorf("first region: got %q, want %q", got, want)
+	}
+	if got, want := regions[1].Name, "Africa (Cape Town)"; got != want {
+		t.Errorf("second region: got %q, want %q", got, want)
+	}
+	if got, want := regions[2].Name, "Asia Pacific (Tokyo)"; got != want {
+		t.Errorf("third region: got %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
  ## Summary

  Store the result of every latency check so failed attempts remain associated with their correct positions.

  ## Problem

  Failed checks were not added to `Latencies`. This caused verbose output to:

  - display successful measurements under the wrong attempt columns;
  - panic with an index-out-of-range error when an attempt failed;
  - calculate invalid averages when no checks succeeded;
  - sort failed regions inconsistently.

  ## Changes

  - Add `AttemptResult` with latency and error fields.
  - Store one result for every check attempt.
  - Calculate average latency using successful attempts only.
  - Return a safe result when no attempts succeed.
  - Display `-` for failed or missing attempts in verbose output.
  - Sort regions without successful measurements after reachable regions.
  - Use stable sorting to preserve the order of equally ranked regions.
  - Keep `Latencies` and `Error` for backward compatibility.
  - Add tests for partial failures, complete failures, output positions, averages, and sorting.

  ## Output example

  A failed first attempt followed by a successful second attempt is now displayed in the correct columns:

  ```text
  Try #1          Try #2     Avg Latency
        -        17.00 ms        17.00 ms
  ```