### PR TITLE
fix(ci): configure golangci-lint

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,15 +20,20 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Go
+    - name: Set up Go for lint
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.26.2
 
     - name: Lint
       uses: golangci/golangci-lint-action@v9.3.0
       with:
         version: v2.12.2
+
+    - name: Set up Go for build and test
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,13 +6,11 @@ on:
       - master
     paths-ignore:
       - '**/*.md'
-      - 'Makefile'
   pull_request:
     branches:
       - master
     paths-ignore:
       - '**/*.md'
-      - 'Makefile'
 
 jobs:
 
@@ -28,13 +26,15 @@ jobs:
         go-version: 1.17
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v9.3.0
+      with:
+        version: v2.12.2
 
     - name: Build
       run: go build -v ./...
 
     - name: Test & Coverage
-      run: go test -v -coverprofile=coverage.out -covermode=atomic
+      run: go test -v -coverprofile=coverage.out -covermode=atomic ./...
 
     - name: Upload coverage to Codecov
       run: bash <(curl -s https://codecov.io/bash)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+version: "2"
+
+linters:
+  # Includes errcheck, govet, ineffassign, staticcheck, and unused.
+  default: standard
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,11 @@ EXEC=${NAME}
 BUILD_DIR=build
 BUILD_OS="windows darwin freebsd linux"
 BUILD_ARCH="amd64 386"
-BUILD_DIR=build
 SRC_CMD=cmd/awsping/main.go
 VERSION=`grep "Version" utils.go | grep -o -E '[0-9]\.[0-9]\.[0-9]{1,2}'`
+GOLANGCI_LINT?=golangci-lint
+
+.PHONY: build clean lint run test check check-version check-master release release-test buildall docker docker-run
 
 build:
 	go build -race -o ${EXEC} ${SRC_CMD}
@@ -20,14 +22,19 @@ clean:
 #
 
 lint:
-	golint
+	$(GOLANGCI_LINT) run ./...
 
 # make run ARGS="-h"
 run:
 	go run cmd/awsping/main.go $(ARGS)
 
-test: lint
-	@go test -cover .
+test:
+	go test -cover ./...
+
+check: lint
+	go test -race ./...
+	go vet ./...
+	go build -v ./...
 
 #
 # Release

--- a/aws_test.go
+++ b/aws_test.go
@@ -41,7 +41,7 @@ func (r *testTarget) GetIP() (*net.TCPAddr, error) {
 func TestAWSRegionCheckLatencyHTTP(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(15 * time.Millisecond)
-		fmt.Fprintln(w, "X")
+		_, _ = fmt.Fprintln(w, "X")
 	}))
 	defer ts.Close()
 

--- a/cmd/awsping/main.go
+++ b/cmd/awsping/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	if *listRegions {
 		lo := awsping.NewOutput(awsping.ShowOnlyRegions, 0)
-		if err := lo.Write(&regions); err != nil {
+		if err := lo.Show(&regions); err != nil {
 			_, _ = fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
@@ -43,7 +43,7 @@ func main() {
 
 	awsping.CalcLatency(regions, *repeats, *useHTTP, *useHTTPS, *service)
 	lo := awsping.NewOutput(*verbose, *repeats)
-	if err := lo.Write(&regions); err != nil {
+	if err := lo.Show(&regions); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/cmd/awsping/main.go
+++ b/cmd/awsping/main.go
@@ -32,7 +32,10 @@ func main() {
 
 	if *listRegions {
 		lo := awsping.NewOutput(awsping.ShowOnlyRegions, 0)
-		lo.Show(&regions)
+		if err := lo.Write(&regions); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 		os.Exit(0)
 	}
 
@@ -40,5 +43,8 @@ func main() {
 
 	awsping.CalcLatency(regions, *repeats, *useHTTP, *useHTTPS, *service)
 	lo := awsping.NewOutput(*verbose, *repeats)
-	lo.Show(&regions)
+	if err := lo.Write(&regions); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }

--- a/request.go
+++ b/request.go
@@ -60,7 +60,9 @@ func (r *AWSRequest) DoHTTP(ua, url string) (time.Duration, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	return latency, nil
 }
@@ -73,7 +75,9 @@ func (r *AWSRequest) DoTCP(_, addr string) (time.Duration, error) {
 		return 0, err
 	}
 	l := time.Since(start)
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close()
+	}()
 
 	return l, nil
 }

--- a/utils.go
+++ b/utils.go
@@ -56,27 +56,38 @@ func NewOutput(level, repeats int) *LatencyOutput {
 	}
 }
 
-func (lo *LatencyOutput) show(regions *AWSRegions) {
+func (lo *LatencyOutput) show(regions *AWSRegions) error {
 	for _, r := range *regions {
-		fmt.Fprintf(lo.w, "%-15s %-s\n", r.Code, r.Name)
+		if _, err := fmt.Fprintf(lo.w, "%-15s %-s\n", r.Code, r.Name); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
-func (lo *LatencyOutput) show0(regions *AWSRegions) {
+func (lo *LatencyOutput) show0(regions *AWSRegions) error {
 	for _, r := range *regions {
-		fmt.Fprintf(lo.w, "%-25s %20s\n", r.Name, r.GetLatencyStr())
+		if _, err := fmt.Fprintf(lo.w, "%-25s %20s\n", r.Name, r.GetLatencyStr()); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
-func (lo *LatencyOutput) show1(regions *AWSRegions) {
+func (lo *LatencyOutput) show1(regions *AWSRegions) error {
 	outFmt := "%5v %-15s %-30s %20s\n"
-	fmt.Fprintf(lo.w, outFmt, "", "Code", "Region", "Latency")
-	for i, r := range *regions {
-		fmt.Fprintf(lo.w, outFmt, i, r.Code, r.Name, r.GetLatencyStr())
+	if _, err := fmt.Fprintf(lo.w, outFmt, "", "Code", "Region", "Latency"); err != nil {
+		return err
 	}
+	for i, r := range *regions {
+		if _, err := fmt.Fprintf(lo.w, outFmt, i, r.Code, r.Name, r.GetLatencyStr()); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func (lo *LatencyOutput) show2(regions *AWSRegions) {
+func (lo *LatencyOutput) show2(regions *AWSRegions) error {
 	// format
 	outFmt := "%5v %-15s %-25s"
 	outFmt += strings.Repeat(" %15s", lo.Repeats) + " %15s\n"
@@ -88,7 +99,9 @@ func (lo *LatencyOutput) show2(regions *AWSRegions) {
 	outStr = append(outStr, "Avg Latency")
 
 	// show header
-	fmt.Fprintf(lo.w, outFmt, outStr...)
+	if _, err := fmt.Fprintf(lo.w, outFmt, outStr...); err != nil {
+		return err
+	}
 
 	// each region stats
 	for i, r := range *regions {
@@ -98,22 +111,32 @@ func (lo *LatencyOutput) show2(regions *AWSRegions) {
 				Duration2ms(r.Latencies[n])))
 		}
 		outData = append(outData, fmt.Sprintf("%.2f ms", r.GetLatency()))
-		fmt.Fprintf(lo.w, outFmt, outData...)
+		if _, err := fmt.Fprintf(lo.w, outFmt, outData...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Write prints data and returns any output error.
+func (lo *LatencyOutput) Write(regions *AWSRegions) error {
+	switch lo.Level {
+	case ShowOnlyRegions:
+		return lo.show(regions)
+	case 0:
+		return lo.show0(regions)
+	case 1:
+		return lo.show1(regions)
+	case 2:
+		return lo.show2(regions)
+	default:
+		return nil
 	}
 }
 
-// Show print data
+// Show prints data and ignores output errors for backward compatibility.
 func (lo *LatencyOutput) Show(regions *AWSRegions) {
-	switch lo.Level {
-	case ShowOnlyRegions:
-		lo.show(regions)
-	case 0:
-		lo.show0(regions)
-	case 1:
-		lo.show1(regions)
-	case 2:
-		lo.show2(regions)
-	}
+	_ = lo.Write(regions)
 }
 
 // GetRegions returns a list of regions

--- a/utils.go
+++ b/utils.go
@@ -118,8 +118,8 @@ func (lo *LatencyOutput) show2(regions *AWSRegions) error {
 	return nil
 }
 
-// Write prints data and returns any output error.
-func (lo *LatencyOutput) Write(regions *AWSRegions) error {
+// Show prints data and returns any output error.
+func (lo *LatencyOutput) Show(regions *AWSRegions) error {
 	switch lo.Level {
 	case ShowOnlyRegions:
 		return lo.show(regions)
@@ -132,11 +132,6 @@ func (lo *LatencyOutput) Write(regions *AWSRegions) error {
 	default:
 		return nil
 	}
-}
-
-// Show prints data and ignores output errors for backward compatibility.
-func (lo *LatencyOutput) Show(regions *AWSRegions) {
-	_ = lo.Write(regions)
 }
 
 // GetRegions returns a list of regions

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,6 +2,7 @@ package awsping
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 	"time"
 )
@@ -111,6 +112,26 @@ func TestOutputShow2(t *testing.T) {
 		"    1 ap-east-1       Asia Pacific (Hong Kong)         25.00 ms        26.00 ms        25.50 ms\n"
 	if got != want {
 		t.Errorf("Show2 failed:\ngot =%q\nwant=%q", got, want)
+	}
+}
+
+type errorWriter struct {
+	err error
+}
+
+func (w errorWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+func TestOutputWriteError(t *testing.T) {
+	want := errors.New("write failed")
+	lo := NewOutput(0, 0)
+	lo.w = errorWriter{err: want}
+	regions := GetRegions()[:1]
+
+	err := lo.Write(&regions)
+	if !errors.Is(err, want) {
+		t.Errorf("Write error: got %v, want %v", err, want)
 	}
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -42,7 +42,9 @@ func TestOutputShowOnlyRegions(t *testing.T) {
 	lo.w = &b
 
 	regions := GetRegions()[:2]
-	lo.Show(&regions)
+	if err := lo.Show(&regions); err != nil {
+		t.Fatalf("Show error: %v", err)
+	}
 
 	got := b.String()
 	want := "af-south-1      Africa (Cape Town)\n" +
@@ -63,7 +65,9 @@ func TestOutputShow0(t *testing.T) {
 	regions[0].Latencies = []time.Duration{15 * time.Millisecond}
 	regions[1].Latencies = []time.Duration{25 * time.Millisecond}
 
-	lo.Show(&regions)
+	if err := lo.Show(&regions); err != nil {
+		t.Fatalf("Show error: %v", err)
+	}
 
 	want := "Africa (Cape Town)                    15.00 ms\n" +
 		"Asia Pacific (Hong Kong)              25.00 ms\n"
@@ -83,7 +87,9 @@ func TestOutputShow1(t *testing.T) {
 	regions[0].Latencies = []time.Duration{15 * time.Millisecond}
 	regions[1].Latencies = []time.Duration{25 * time.Millisecond}
 
-	lo.Show(&regions)
+	if err := lo.Show(&regions); err != nil {
+		t.Fatalf("Show error: %v", err)
+	}
 
 	got := b.String()
 	want := "      Code            Region                                      Latency\n" +
@@ -104,7 +110,9 @@ func TestOutputShow2(t *testing.T) {
 	regions[0].Latencies = []time.Duration{15 * time.Millisecond, 17 * time.Millisecond}
 	regions[1].Latencies = []time.Duration{25 * time.Millisecond, 26 * time.Millisecond}
 
-	lo.Show(&regions)
+	if err := lo.Show(&regions); err != nil {
+		t.Fatalf("Show error: %v", err)
+	}
 
 	got := b.String()
 	want := "      Code            Region                             Try #1          Try #2     Avg Latency\n" +
@@ -123,15 +131,15 @@ func (w errorWriter) Write([]byte) (int, error) {
 	return 0, w.err
 }
 
-func TestOutputWriteError(t *testing.T) {
+func TestOutputShowError(t *testing.T) {
 	want := errors.New("write failed")
 	lo := NewOutput(0, 0)
 	lo.w = errorWriter{err: want}
 	regions := GetRegions()[:1]
 
-	err := lo.Write(&regions)
+	err := lo.Show(&regions)
 	if !errors.Is(err, want) {
-		t.Errorf("Write error: got %v, want %v", err, want)
+		t.Errorf("Show error: got %v, want %v", err, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- pin golangci-lint-action v9.3.0 and golangci-lint v2.12.2
- add a version 2 golangci-lint configuration with the standard linter set
- handle output errors and explicitly ignore cleanup errors
- run coverage across all packages
- replace golint with golangci-lint in the Makefile
- add a make check target for lint, race tests, vet, and build

## Problem

The existing golangci-lint-action v2 replaces Go 1.17 with Go 1.26 and then runs a linter built with Go 1.24. The lint step fails before checking the project with a toolchain compatibility error.

## Verification

```text
make check
```

This runs successfully with golangci-lint v2.12.2 and reports 0 issues.