### PR TITLE
chore(toolchain): update Go and CI images

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -7,28 +7,32 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v7.0.0
         with:
-          go-version: 1.17
+          go-version: '1.26.5'
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,28 +12,27 @@ on:
     paths-ignore:
       - '**/*.md'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
 
   build:
     name: Build, Test, Coverage
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7.0.1
 
-    - name: Set up Go for lint
-      uses: actions/setup-go@v2
+    - name: Set up Go
+      uses: actions/setup-go@v7.0.0
       with:
-        go-version: 1.26.2
+        go-version: '1.26.5'
 
     - name: Lint
       uses: golangci/golangci-lint-action@v9.3.0
       with:
         version: v2.12.2
-
-    - name: Set up Go for build and test
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
 
     - name: Build
       run: go build -v ./...
@@ -42,4 +41,8 @@ jobs:
       run: go test -v -coverprofile=coverage.out -covermode=atomic ./...
 
     - name: Upload coverage to Codecov
-      run: bash <(curl -s https://codecov.io/bash)
+      uses: codecov/codecov-action@v7.0.0
+      with:
+        fail_ci_if_error: true
+        files: ./coverage.out
+        use_oidc: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
-FROM golang:1.17-bullseye as build
-COPY . /build
-WORKDIR /build
-RUN make
+FROM golang:1.26.5-trixie AS build
 
-FROM gcr.io/distroless/base
-COPY --from=build /build/awsping /
+WORKDIR /src
+COPY go.mod ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -trimpath \
+    -ldflags="-s -w" \
+    -o /out/awsping \
+    ./cmd/awsping
 
+FROM gcr.io/distroless/static-debian13:nonroot
+
+COPY --from=build --chown=nonroot:nonroot /out/awsping /awsping
+
+USER nonroot:nonroot
 ENTRYPOINT ["/awsping"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,6 @@
-FROM gcr.io/distroless/base
-COPY awsping /
+FROM gcr.io/distroless/static-debian13:nonroot
 
+COPY --chown=nonroot:nonroot awsping /awsping
+
+USER nonroot:nonroot
 ENTRYPOINT ["/awsping"]

--- a/aws_test.go
+++ b/aws_test.go
@@ -138,7 +138,7 @@ func TestAWSRegionCheckLatencyTCP(t *testing.T) {
 	want := 15.0
 
 	if got < want || got > want+1 {
-		t.Errorf("failed:\ngot=%f\nwant=%f\nregion=%q", got, want, regions[0])
+		t.Errorf("failed:\ngot=%f\nwant=%f\nregion=%v", got, want, regions[0])
 	}
 
 	if regions[0].Error != nil {
@@ -248,7 +248,7 @@ func TestAWSRegionsLen(t *testing.T) {
 	want := len(regions)
 
 	if got != want {
-		t.Errorf("failed:\ngot=%q\nwant=%q", got, want)
+		t.Errorf("failed:\ngot=%d\nwant=%d", got, want)
 	}
 }
 
@@ -259,7 +259,7 @@ func TestAWSRegionsLess(t *testing.T) {
 	regions[1].Latencies = []time.Duration{25 * time.Millisecond}
 
 	if !regions.Less(0, 1) {
-		t.Errorf("failed: not less, regions=%q", regions)
+		t.Errorf("failed: not less, regions=%v", regions)
 	}
 }
 
@@ -286,7 +286,7 @@ func TestAWSRegionsSwap(t *testing.T) {
 	regions.Swap(0, 3)
 
 	if len(regions[0].Latencies) != 0 {
-		t.Errorf("failed: not swapped, regions=%q", regions)
+		t.Errorf("failed: not swapped, regions=%v", regions)
 	}
 }
 
@@ -297,7 +297,7 @@ func TestAWSRegionsSetService(t *testing.T) {
 	regions.SetService(service)
 
 	if regions[0].Service != service || regions[len(regions)-1].Service != service {
-		t.Errorf("failed: not set, regions=%q, service=%s", regions, service)
+		t.Errorf("failed: not set, regions=%v, service=%s", regions, service)
 	}
 }
 
@@ -308,7 +308,7 @@ func TestAWSRegionsSetCheckType(t *testing.T) {
 	regions.SetCheckType(checkType)
 
 	if regions[0].CheckType != checkType || regions[len(regions)-1].CheckType != checkType {
-		t.Errorf("failed: not set, regions=%q, checkType=%d", regions, checkType)
+		t.Errorf("failed: not set, regions=%v, checkType=%d", regions, checkType)
 	}
 }
 

--- a/cmd/awsping/main.go
+++ b/cmd/awsping/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/ekalinin/awsping"
 )
@@ -38,8 +36,6 @@ func main() {
 		}
 		os.Exit(0)
 	}
-
-	rand.Seed(time.Now().UnixNano())
 
 	awsping.CalcLatency(regions, *repeats, *useHTTP, *useHTTPS, *service)
 	lo := awsping.NewOutput(*verbose, *repeats)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/ekalinin/awsping
 
-go 1.17
+go 1.26.0


### PR DESCRIPTION
## Summary

- update the module and GitHub Actions to Go 1.26.5
- update checkout, setup-go, Codecov, and Docker login actions
- move container images to Debian 13 distroless and run as a non-root user
- remove obsolete manual random seeding and fix format directives reported by the new toolchain

## Verification

- make check with golangci-lint v2.12.2
- GOTOOLCHAIN=go1.26.5 go test ./...
- static Linux amd64 build with Go 1.26.5
- actionlint for the PR workflow
- Docker image manifests resolved successfully

A full local Docker build was not run because the Docker daemon is unavailable. The remaining actionlint warning for goreleaser/goreleaser-action@v2 belongs to the separate GoReleaser v2 migration.